### PR TITLE
adding o365 URL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   },
   "content_scripts": [{
     "js": ["content.js"],
-    "matches": ["https://outlook.live.com/mail/*", "https://outlook.live.com/owa/*","https://outlook.office.com/owa/*","https://outlook.office.com/mail/*"]
+    "matches": ["https://outlook.live.com/mail/*", "https://outlook.live.com/owa/*","https://outlook.office.com/owa/*","https://outlook.office.com/mail/*", "https://outlook.office365.com/mail/*"]
   }]
 
 }


### PR DESCRIPTION
Hi there, 

I noticed mail app from outlook.office365.com was missing.

Cheers,
Vianney